### PR TITLE
Remove erroneous `if` statement in `fashion_mnist_training.py`.

### DIFF
--- a/samples/fashion-mnist/fashion_mnist_training.py
+++ b/samples/fashion-mnist/fashion_mnist_training.py
@@ -98,5 +98,4 @@ if __name__ == '__main__':
     finally:
         # Enable ibm-zdnn-plugin for inference.
         print()
-        if disable_nnpa:
-            del os.environ['NNPA_DEVICES']
+        del os.environ['NNPA_DEVICES']


### PR DESCRIPTION
The code should unconditionally remove `NNPA_DEVICES` from the environment. Here it make no difference as the process running the Python code will go away, but this was so users would know they might need similar code in other cases.