### PR TITLE
Deprecate

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-# IBM-zDNN-Plugin v1.1
+# Deprecated
+
+## Please visit [IBM Z Accelerated for TensorFlow](https://github.com/IBM/ibmz-accelerated-for-tensorflow)
+
+# Deprecated - IBM-zDNN-Plugin v1.1
 
 ## Table of Contents
 


### PR DESCRIPTION
Removed ibm-zdnn-plugin 1.1.0 from PyPI. 
Deprecating the external githib page.